### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/Dinoshauer/name-me.svg?branch=master)](https://travis-ci.org/Dinoshauer/name-me)
 [![Coverage Status](https://img.shields.io/coveralls/Dinoshauer/name-me.svg)](https://coveralls.io/r/Dinoshauer/name-me?branch=master)
-[![Latest Version](https://img.shields.io/pypi/v/name-me.svg
-[![License](https://img.shields.io/pypi/l/name-me.svg
+[![Latest Version](https://img.shields.io/pypi/v/name-me.svg)](https://pypi.python.org/pypi/name-me/)
+[![License](https://img.shields.io/pypi/l/name-me.svg)](https://pypi.python.org/pypi/name-me/)
 
 
 NameMe

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/Dinoshauer/name-me.svg?branch=master)](https://travis-ci.org/Dinoshauer/name-me)
 [![Coverage Status](https://img.shields.io/coveralls/Dinoshauer/name-me.svg)](https://coveralls.io/r/Dinoshauer/name-me?branch=master)
-[![Latest Version](https://pypip.in/version/name-me/badge.png)](https://pypi.python.org/pypi/name-me/)
-[![License](https://pypip.in/license/name-me/badge.png)](https://pypi.python.org/pypi/name-me/)
+[![Latest Version](https://img.shields.io/pypi/v/name-me.svg
+[![License](https://img.shields.io/pypi/l/name-me.svg
 
 
 NameMe


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20name-me))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `name-me`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.